### PR TITLE
feat: replace dashboard spinner with skeleton loader

### DIFF
--- a/app/(user)/(dashboard)/@main/loading.tsx
+++ b/app/(user)/(dashboard)/@main/loading.tsx
@@ -1,9 +1,16 @@
-import LoadingSVG from '@/public/img/icons/loader.svg'
+import { Skeleton } from '@/components/ui/skeleton'
 
 export default function Loading() {
+  
   return (
-    <div className="flex h-full w-full items-center justify-center rounded-xl bg-loading/50">
-      <LoadingSVG className="size-7 animate-spin" />
+    <div className="flex h-full w-full flex-col gap-6 rounded-xl p-6">
+      <Skeleton className="h-8 w-1/3" />
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+      <Skeleton className="h-24 w-full" />
     </div>
   )
 }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/utils'
+
+interface SkeletonProps {
+  className?: string
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-md bg-muted',
+        className
+      )}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
Replaced the spinner-based dashboard loading UI with a skeleton loader using Next.js App Router `loading.tsx`.

## Changes
- Added a reusable Skeleton component
- Implemented dashboard-style skeleton layout
- No business logic or API changes

## Notes
Local preview is limited due to Auth0-protected routes requiring secrets.

Fixes #29
