### PR TITLE
Fix #46: Make copyright year dynamic in footer

### DIFF
--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -114,7 +114,7 @@ export function Footer() {
         </div>
       </MotionDiv>
       <p className="text-center max-sm:text-sm">
-        © 2025 — BrainBytes by{' '}
+        © {new Date().getFullYear()} — BrainBytes by{' '}
         <a
           href="https://github.com/Oreek"
           target="_blank"


### PR DESCRIPTION
## Description
This PR fixes issue by making the copyright year in the footer dynamic, so it automatically updates to reflect the current year.

## Changes Made
- Updated the copyright text in the Footer component from hardcoded `© 2025` to `© {new Date().getFullYear()}`
- The year will now automatically display 2026 and update every year going forward

## Testing
- ✅ The footer now displays "© 2026 — BrainBytes" 
- ✅ Will automatically update in future years
- ✅ No breaking changes or additional dependencies required

## Screenshot

<img width="1876" height="426" alt="image" src="https://github.com/user-attachments/assets/09f4d3f0-f4b5-47d5-ba73-1598ee72fb5f" />


## Related Issue
Fixes #46