### PR TITLE
ci: consolidate linting to avoid redundant ESLint runs (Issue #50)

### DIFF
--- a/.github/workflows/web-app-ci.yml
+++ b/.github/workflows/web-app-ci.yml
@@ -129,24 +129,8 @@ jobs:
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
-      - name: Run ESLint with output
-        id: eslint
-        run: pnpm lint --format=json --output-file=eslint-report.json
-        continue-on-error: true
-      
-      - name: Comment PR with lint results
-        if: github.event_name == 'pull_request' && steps.eslint.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const report = JSON.parse(fs.readFileSync('eslint-report.json', 'utf8'));
-            const errors = report.reduce((acc, file) => acc + file.messages.length, 0);
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `⚠️ ESLint found ${errors} issue(s). Please fix them before merging.`
-            });
-        continue-on-error: true
+
+      # NOTE: Linting and lint-reporting are consolidated into the `lint-type-build` job
+      # to avoid running ESLint twice and to reduce CI minutes.
+      - name: Placeholder - code quality checks
+        run: echo "Code quality job reserved for future checks (linting moved to lint-type-build)"


### PR DESCRIPTION
Consolidate ESLint steps to the lint job to avoid running the linter twice (previously duplicated in another job). This saves CI minutes and produces a single lint report.\n\nCloses #50