### PR TITLE
ci(tests): run test suite in Web App CI (Issue #47)

### DIFF
--- a/.github/workflows/web-app-ci.yml
+++ b/.github/workflows/web-app-ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
+      - name: Run tests
+        run: pnpm test
+
       - name: Run linter
         run: pnpm lint
         continue-on-error: true


### PR DESCRIPTION
This PR ensures the Web App CI runs the test suite by adding a dedicated 'Run tests' step that executes 'pnpm test'.

Closes #47.,