### PR TITLE
chore(next): remove Clerk image host from remotePatterns (Issue #49)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,10 +22,7 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
       },
-      {
-        protocol: 'https',
-        hostname: 'img.clerk.com',
-      },
+
     ],
   },
   webpack(config) {


### PR DESCRIPTION
This PR removes img.clerk.com from Next.js remotePatterns since the project uses Auth0, not Clerk.\n\nCloses #49