### PR TITLE
feat(stripe): make subscription price configurable via env vars (Issue #11)

### DIFF
--- a/actions/user-subscription.ts
+++ b/actions/user-subscription.ts
@@ -24,7 +24,19 @@ const SUBSCRIPTION_PRICE_CENTS = (() => {
 
   return parsed;
 })();
-const SUBSCRIPTION_CURRENCY = process.env.STRIPE_SUBSCRIPTION_CURRENCY ?? "USD";
+const RAW_SUBSCRIPTION_CURRENCY =
+  process.env.STRIPE_SUBSCRIPTION_CURRENCY ?? "USD";
+const SUBSCRIPTION_CURRENCY = (() => {
+  const normalized = RAW_SUBSCRIPTION_CURRENCY.toLowerCase();
+  // Basic validation: must be a 3-letter ISO-style currency code
+  if (!/^[a-z]{3}$/.test(normalized)) {
+    throw new Error(
+      `Invalid STRIPE_SUBSCRIPTION_CURRENCY value "${RAW_SUBSCRIPTION_CURRENCY}". ` +
+        "Expected a 3-letter ISO currency code (e.g., 'usd')."
+    );
+  }
+  return normalized;
+})();
 const rawSubscriptionInterval = process.env.STRIPE_SUBSCRIPTION_INTERVAL;
 const SUBSCRIPTION_INTERVAL: "month" | "year" =
   rawSubscriptionInterval === "month" || rawSubscriptionInterval === "year"


### PR DESCRIPTION
Fixes #11

This PR makes the Stripe subscription pricing configurable through environment variables instead of using hardcoded values.

## Changes
- Add `STRIPE_SUBSCRIPTION_PRICE_CENTS` env var (default: 2000)
- Add `STRIPE_SUBSCRIPTION_CURRENCY` env var (default: USD)
- Add `STRIPE_SUBSCRIPTION_INTERVAL` env var (default: month)
- Replace hardcoded values in Stripe checkout session creation

## Benefits
- Easier to change pricing without code modifications
- Support different currencies and billing intervals
- Better configuration management across environments