### PR TITLE
Disable sidebar navigation until course is selected (Fixes #36)

### DIFF
--- a/components/user/SideMenu.tsx
+++ b/components/user/SideMenu.tsx
@@ -1,11 +1,15 @@
-import NextLink from 'next/link'
-import { SideMenuItem } from '@/components/user/SideMenuItem'
-import { SideMenuThemeButton } from '@/components/user/SideMenuThemeButton'
-import { SideMenuUserButton } from '@/components/user/SideMenuUserButton'
+"use client";
 
-import LogoSVG from '@/public/logo.svg'
+import NextLink from "next/link";
+import { SideMenuItem } from "@/components/user/SideMenuItem";
+import { SideMenuThemeButton } from "@/components/user/SideMenuThemeButton";
+import { SideMenuUserButton } from "@/components/user/SideMenuUserButton";
+import LogoSVG from "@/public/logo.svg";
+import { useDashboardNavEnabled } from "@/hooks/useDashboardNavEnabled";
 
 export function SideMenu() {
+  const { navEnabled } = useDashboardNavEnabled();
+
   return (
     <div className="flex h-full flex-col justify-between pt-6">
       <nav className="flex flex-col gap-6 px-4 sm:max-lg:px-2">
@@ -24,11 +28,36 @@ export function SideMenu() {
         </NextLink>
         <ul className="flex flex-col gap-y-2">
           <SideMenuItem href="/learn" icon="learn" label="Learn" />
-          <SideMenuItem href="/leaderboard" icon="leaderboard" label="Leaderboard" />
-          <SideMenuItem href="/quests" icon="quests" label="Quests" />
-          <SideMenuItem href="/forum" icon="forum" label="Forum" />
-          <SideMenuItem href="/compete" icon="code" label="Compete" />
-          <SideMenuItem href="/shop" icon="shop" label="Shop" />
+          <SideMenuItem
+            href="/leaderboard"
+            icon="leaderboard"
+            label="Leaderboard"
+            disabled={!navEnabled}
+          />
+          <SideMenuItem
+            href="/quests"
+            icon="quests"
+            label="Quests"
+            disabled={!navEnabled}
+          />
+          <SideMenuItem
+            href="/forum"
+            icon="forum"
+            label="Forum"
+            disabled={!navEnabled}
+          />
+          <SideMenuItem
+            href="/compete"
+            icon="code"
+            label="Compete"
+            disabled={!navEnabled}
+          />
+          <SideMenuItem
+            href="/shop"
+            icon="shop"
+            label="Shop"
+            disabled={!navEnabled}
+          />
         </ul>
       </nav>
       <div className="space-y-2 border-t-2 px-4 pb-2 pt-2 sm:max-lg:px-2">
@@ -36,5 +65,5 @@ export function SideMenu() {
         <SideMenuUserButton />
       </div>
     </div>
-  )
+  );
 }

--- a/components/user/SideMenuItem.tsx
+++ b/components/user/SideMenuItem.tsx
@@ -1,29 +1,46 @@
-'use client'
+"use client";
 
-import type { Route } from 'next'
-import NextImage from 'next/image'
-import NextLink from 'next/link'
-import { usePathname } from 'next/navigation'
-import { Button } from '@/components/ui/button'
+import type { Route } from "next";
+import NextImage from "next/image";
+import NextLink from "next/link";
+import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 type SideMenuItemProps = {
-  label: string
-  icon: string
-  href: Route | string
-  hideLabel?: boolean
-}
+  label: string;
+  icon: string;
+  href: Route | string;
+  hideLabel?: boolean;
+  disabled?: boolean;
+};
 
-export function SideMenuItem({ href, icon, label, hideLabel }: SideMenuItemProps) {
-  const pathname = usePathname()
-  const isActive = pathname === href
+export function SideMenuItem({
+  href,
+  icon,
+  label,
+  hideLabel,
+  disabled = false,
+}: SideMenuItemProps) {
+  const pathname = usePathname();
+  const isActive = pathname === href;
+
+  const commonClasses =
+    "h-auto w-full justify-start py-2 sm:max-lg:w-auto sm:max-lg:px-2";
+  const stateClasses = disabled
+    ? "opacity-50 cursor-not-allowed"
+    : isActive
+    ? "border-b-2"
+    : "text-foreground/85";
+
   return (
     <li>
-      <Button
-        variant={isActive ? 'active' : 'ghost'}
-        className={`h-auto w-full justify-start py-2 sm:max-lg:w-auto sm:max-lg:px-2 ${isActive ? 'border-b-2' : 'text-foreground/85'}`}
-        asChild
-      >
-        <NextLink href={href as Route} title={label} {...(hideLabel && { 'aria-label': label })}>
+      {disabled ? (
+        <Button
+          variant="ghost"
+          className={`${commonClasses} ${stateClasses}`}
+          aria-disabled="true"
+          tabIndex={-1}
+        >
           <span className="relative block size-10">
             <NextImage
               className="object-cover"
@@ -33,8 +50,32 @@ export function SideMenuItem({ href, icon, label, hideLabel }: SideMenuItemProps
             />
           </span>
           {!hideLabel && <span className="ml-5 truncate sm:max-lg:sr-only">{label}</span>}
-        </NextLink>
-      </Button>
+        </Button>
+      ) : (
+        <Button
+          variant={isActive ? "active" : "ghost"}
+          className={`${commonClasses} ${stateClasses}`}
+          asChild
+        >
+          <NextLink
+            href={href as Route}
+            title={label}
+            {...(hideLabel && { "aria-label": label })}
+          >
+            <span className="relative block size-10">
+              <NextImage
+                className="object-cover"
+                src={`/img/icons/${icon}.svg`}
+                alt={`${label} icon`}
+                fill
+              />
+            </span>
+            {!hideLabel && (
+              <span className="ml-5 truncate sm:max-lg:sr-only">{label}</span>
+            )}
+          </NextLink>
+        </Button>
+      )}
     </li>
-  )
+  );
 }

--- a/hooks/useDashboardNavEnabled.ts
+++ b/hooks/useDashboardNavEnabled.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export function useDashboardNavEnabled() {
+  const pathname = usePathname();
+
+  const isOnCourseSelection =
+    pathname === "/courses" ||
+    pathname.startsWith("/buttons");
+
+  const navEnabled = !isOnCourseSelection;
+
+  return { navEnabled };
+}


### PR DESCRIPTION
Implemented sidebar disable feature as discussed.

When user hasn't selected a course (on /courses), Quests/Shop/Forum/Compete/Leaderboard are disabled.
Once course is selected (/learn), all items become enabled.

**Changes:**
- `hooks/useDashboardNavEnabled.ts` - detects course selection
- `components/user/SideMenu.tsx` - uses hook to control sidebar
- `components/user/SideMenuItem.tsx` - supports disabled state

## Fixes #36