### PR TITLE
feat: implement per-user rate limiting for API routes

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -207,8 +207,11 @@ export async function POST(req: NextRequest) {
   if (process.env.NODE_ENV !== 'development') {
     try {
       const { tier, limit } = await resolveUserTier(user)
-      rlLimit = limit
-      const rl = await checkRateLimit(user.id, rlLimit)
+      const route = '/api/chat'
+      const effectiveLimit = Math.min(limit, 10)
+
+      rlLimit = effectiveLimit
+      const rl = await checkRateLimit(user.id, rlLimit, route)
       // Attach rate limit headers on responses
       if (!rl.allowed) {
         let response = new NextResponse('Too Many Requests', {

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -17,6 +17,11 @@ const WINDOW_MS = 60_000 // 1 minute
 const store = new Map<string, { count: number; windowStart: number }>()
 
 export async function resolveUserTier(user: any): Promise<{ tier: Tier; limit: number }> {
+  const userId = user?.id
+
+  if(!userId) {
+    return {tier: 'standard', limit: DEFAULT_LIMITS.standard}
+  }
   // Admin check
   const isAdmin = await getIsAdmin()
   if (isAdmin) return { tier: 'admin', limit: DEFAULT_LIMITS.admin }
@@ -28,23 +33,23 @@ export async function resolveUserTier(user: any): Promise<{ tier: Tier; limit: n
   return { tier: 'standard', limit: DEFAULT_LIMITS.standard }
 }
 
-export async function checkRateLimit(userId: string, limit: number) {
-  const key = `rl:${userId}`
+export async function checkRateLimit(userId: string, limit: number, route: string) {
+  const key = `rl:${userId}:${route}`
   const now = Date.now()
   const entry = store.get(key)
 
   if (!entry || now - entry.windowStart >= WINDOW_MS) {
     store.set(key, { count: 1, windowStart: now })
-    return { allowed: true, remaining: limit - 1, reset: now + WINDOW_MS }
+    return { allowed: true, remaining: limit - 1, reset: now + WINDOW_MS, limit }
   }
 
   if (entry.count >= limit) {
-    return { allowed: false, remaining: 0, reset: entry.windowStart + WINDOW_MS }
+    return { allowed: false, remaining: 0, reset: entry.windowStart + WINDOW_MS, limit }
   }
 
   entry.count += 1
   store.set(key, entry)
-  return { allowed: true, remaining: Math.max(0, limit - entry.count), reset: entry.windowStart + WINDOW_MS }
+  return { allowed: true, remaining: Math.max(0, limit - entry.count), reset: entry.windowStart + WINDOW_MS, limit }
 }
 
 // Used by tests to reset state


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->
Fixes : #80 
Add per-user rate limiting to avoid excessive API use
## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

<!-- List the specific changes made in this PR -->

- Created route for `/api/chat`
- Added logic for if user id not found, return default limits

## Testing

<!-- Describe how you tested your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have tested my changes thoroughly
- [ ] I have updated the documentation (if needed)
- [ ] My changes generate no new warnings or errors
